### PR TITLE
Implement manual membership activation

### DIFF
--- a/backend/apps/api-gateway/src/app.controller.ts
+++ b/backend/apps/api-gateway/src/app.controller.ts
@@ -5,6 +5,9 @@ import {
   Post,
   Inject,
   Body,
+  Patch,
+  Param,
+  Request,
   UseGuards,
   HttpCode,
   HttpStatus,
@@ -57,5 +60,18 @@ export class AppController {
   @HttpCode(HttpStatus.OK)
   findAllGyms() {
     return this.gymClient.send({ cmd: 'find_all_gyms' }, {});
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('memberships/:id/activate')
+  @HttpCode(HttpStatus.OK)
+  activateMembership(@Param('id') membershipId: string, @Request() req: any) {
+    const managerId = req.user.sub;
+    const payload = {
+      membershipId,
+      managerId,
+    };
+
+    return this.gymClient.send({ cmd: 'activate_membership' }, payload);
   }
 }

--- a/backend/apps/gym-management-service/src/app.controller.ts
+++ b/backend/apps/gym-management-service/src/app.controller.ts
@@ -2,6 +2,7 @@ import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { AppService } from './app.service';
 import { CreateGymDto } from './dto/create-gym.dto';
+import { ActivateMembershipDto } from './dto/activate-membership.dto';
 
 @Controller()
 export class AppController {
@@ -20,5 +21,10 @@ export class AppController {
   @MessagePattern({ cmd: 'find_all_gyms' })
   findAllGyms() {
     return this.appService.findAllGyms();
+  }
+
+  @MessagePattern({ cmd: 'activate_membership' })
+  activateMembership(@Payload() activateMembershipDto: ActivateMembershipDto) {
+    return this.appService.activateMembership(activateMembershipDto);
   }
 }

--- a/backend/apps/gym-management-service/src/dto/activate-membership.dto.ts
+++ b/backend/apps/gym-management-service/src/dto/activate-membership.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class ActivateMembershipDto {
+  @IsUUID(4, { message: 'El ID de la membresía debe ser un UUID válido.' })
+  @IsNotEmpty({ message: 'El ID de la membresía no puede estar vacío.' })
+  membershipId: string;
+
+  @IsUUID(4, { message: 'El ID del manager debe ser un UUID válido.' })
+  @IsNotEmpty({ message: 'El ID del manager no puede estar vacío.' })
+  managerId: string;
+}


### PR DESCRIPTION
## Summary
- implement ActivateMembershipDto
- add membership activation logic to Gym Management Service
- expose `activate_membership` message pattern
- add PATCH endpoint in API Gateway for manual membership activation

## Testing
- `pnpm test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859f16b731c832880a4172f13d523c6