### PR TITLE
feat(api): Implement public and admin gym endpoints with DTOs

### DIFF
--- a/backend/apps/api-gateway/src/app.controller.ts
+++ b/backend/apps/api-gateway/src/app.controller.ts
@@ -13,6 +13,8 @@ import {
 import { ClientProxy } from '@nestjs/microservices';
 import { firstValueFrom } from 'rxjs';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
+import { RolesGuard } from './auth/roles.guard';
+import { Roles } from './auth/roles.decorator';
 
 @Controller('v1') // Prefijo para todas las rutas de este controlador
 export class AppController {
@@ -45,17 +47,25 @@ export class AppController {
     }
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
   @Post('gyms')
   @HttpCode(HttpStatus.CREATED)
   createGym(@Body() body: any) {
     return this.gymClient.send({ cmd: 'create_gym' }, body);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
   @Get('gyms')
   @HttpCode(HttpStatus.OK)
   findAllGyms() {
     return this.gymClient.send({ cmd: 'find_all_gyms' }, {});
+  }
+
+  @Get('public/gyms')
+  @HttpCode(HttpStatus.OK)
+  findAllPublicGyms() {
+    return this.gymClient.send({ cmd: 'find_all_public_gyms' }, {});
   }
 }

--- a/backend/apps/api-gateway/src/app.module.ts
+++ b/backend/apps/api-gateway/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AppController } from './app.controller';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
+import { RolesGuard } from './auth/roles.guard';
 
 @Module({
   imports: [
@@ -46,6 +47,6 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard';
     ]),
   ],
   controllers: [AppController],
-  providers: [JwtAuthGuard],
+  providers: [JwtAuthGuard, RolesGuard],
 })
 export class AppModule {}

--- a/backend/apps/api-gateway/src/auth/roles.decorator.ts
+++ b/backend/apps/api-gateway/src/auth/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/apps/api-gateway/src/auth/roles.guard.ts
+++ b/backend/apps/api-gateway/src/auth/roles.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    if (!user || !user.role) {
+      throw new ForbiddenException('Access denied');
+    }
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/backend/apps/gym-management-service/src/app.controller.ts
+++ b/backend/apps/gym-management-service/src/app.controller.ts
@@ -22,6 +22,11 @@ export class AppController {
     return this.appService.findAllGyms();
   }
 
+  @MessagePattern({ cmd: 'find_all_public_gyms' })
+  findAllPublicGyms() {
+    return this.appService.findAllPublicGyms();
+  }
+
   @EventPattern('user_created')
   handleUserCreated(
     @Payload() data: { id: string; email: string; firstName?: string; lastName?: string },

--- a/backend/apps/gym-management-service/src/app.service.ts
+++ b/backend/apps/gym-management-service/src/app.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma/prisma.service';
 import { CreateGymDto } from './dto/create-gym.dto';
+import { PublicGymDto } from './dto/public-gym.dto';
+import { AdminGymDto } from './dto/admin-gym.dto';
 
 @Injectable()
 export class AppService {
@@ -16,8 +18,24 @@ export class AppService {
     });
   }
 
-  async findAllGyms() {
-    return this.prisma.gym.findMany();
+  async findAllGyms(): Promise<AdminGymDto[]> {
+    const gyms = await this.prisma.gym.findMany();
+    return gyms.map((gym) => ({
+      id: gym.id,
+      name: gym.name,
+      uniqueCode: gym.uniqueCode,
+      isActive: gym.isActive,
+      createdAt: gym.createdAt,
+    }));
+  }
+
+  async findAllPublicGyms(): Promise<PublicGymDto[]> {
+    const gyms = await this.prisma.gym.findMany({
+      where: { isActive: true },
+    });
+    return gyms.map((gym) => ({
+      name: gym.name,
+    }));
   }
 
   async createLocalUser(data: { id: string; email: string; firstName?: string; lastName?: string }) {

--- a/backend/apps/gym-management-service/src/dto/admin-gym.dto.ts
+++ b/backend/apps/gym-management-service/src/dto/admin-gym.dto.ts
@@ -1,0 +1,7 @@
+export class AdminGymDto {
+  id: string;
+  name: string;
+  uniqueCode: string;
+  isActive: boolean;
+  createdAt: Date;
+}

--- a/backend/apps/gym-management-service/src/dto/public-gym.dto.ts
+++ b/backend/apps/gym-management-service/src/dto/public-gym.dto.ts
@@ -1,0 +1,3 @@
+export class PublicGymDto {
+  name: string;
+}


### PR DESCRIPTION
This commit introduces a clear separation between public-facing and administrative data for the gym listings, enhancing both security and API design.

- **API Gateway (`api-gateway`):**
    - Secured the existing `GET /v1/gyms` endpoint, restricting access to users with the 'OWNER' role via `RolesGuard`.
    - Added a new, unprotected public endpoint `GET /v1/public/gyms` to allow unauthenticated users (e.g., on the registration page) to view a list of available gyms.

- **Gym Management Service (`gym-management-service`):**
    - Created `PublicGymDto` and `AdminGymDto` to control the data exposed by each endpoint.
    - The new `findAllPublicGyms` service method returns only non-sensitive information (e.g., gym name) suitable for public view.
    - The `findAllGyms` method now maps its results to `AdminGymDto`, ensuring that detailed fields like `uniqueCode` and `createdAt` are only sent to authorized administrative roles.